### PR TITLE
feat: paginate RepositoryService.getTeams using PaginatedRequest

### DIFF
--- a/src/main/kotlin/com/soprasteria/github/internal/GitHubRepositoryClient.kt
+++ b/src/main/kotlin/com/soprasteria/github/internal/GitHubRepositoryClient.kt
@@ -47,14 +47,8 @@ internal class GitHubRepositoryClient(
         owner: String,
         repositoryName: String,
     ): List<GitHubRepositoryTeam> {
-        val lens = Body.auto<List<GetTeamResponse>>().toLens()
-        val request = GetRequest(GitHubApiEndpoints.repositoryTeams(owner, repositoryName))
-        val response = client(request)
-
-        return when (response.status) {
-            Status.OK -> lens(response).map { it.toRepositoryTeam(owner) }
-            else -> throw GitHubApiException.from(response, "getTeams($owner, $repositoryName)")
-        }
+        val request = PaginatedRequest<GetTeamResponse>(GitHubApiEndpoints.repositoryTeams(owner, repositoryName))
+        return request(client).map { it.toRepositoryTeam(owner) }
     }
 
     fun getCollaborators(

--- a/src/test/kotlin/com.soprasteria.github/Defaults.kt
+++ b/src/test/kotlin/com.soprasteria.github/Defaults.kt
@@ -3,6 +3,7 @@ package com.soprasteria.github
 import com.soprasteria.github.organization.GitHubOrganization
 import com.soprasteria.github.repository.GitHubRepository
 import com.soprasteria.github.repository.GitHubRepositoryContributor
+import com.soprasteria.github.repository.GitHubRepositoryTeam
 import com.soprasteria.github.team.GitHubTeam
 import com.soprasteria.github.team.GitHubTeamMember
 
@@ -50,6 +51,30 @@ object Defaults {
         type = "User",
         siteAdmin = false,
         contributions = contributions,
+    )
+
+    fun repositoryTeam(
+        organization: String = OWNER,
+        id: Int = 1,
+        name: String = "Justice League",
+        slug: String = "justice-league",
+        description: String = "The best team",
+        privacy: String = "secret",
+        permission: String = "pull",
+    ) = GitHubRepositoryTeam(
+        organization = organization,
+        id = id,
+        nodeId = "T_kwDOA$id",
+        url = "https://api.github.com/teams/$id",
+        htmlUrl = "https://github.com/orgs/$organization/teams/$slug",
+        name = name,
+        slug = slug,
+        description = description,
+        privacy = privacy,
+        notificationSetting = "notifications_enabled",
+        permission = permission,
+        membersUrl = "https://api.github.com/teams/$id/members{/member}",
+        repositoriesUrl = "https://api.github.com/teams/$id/repos",
     )
 
     fun team() =

--- a/src/test/kotlin/com.soprasteria.github/GitHubRepositorySpec.kt
+++ b/src/test/kotlin/com.soprasteria.github/GitHubRepositorySpec.kt
@@ -24,7 +24,7 @@ class GitHubRepositorySpec :
         "repositories.getTeams" should {
 
             "return Found with an empty list when the repository has no teams" {
-                every { httpClient.invoke(matchUri("/repos/${repo.owner}/${repo.name}/teams")) }
+                every { httpClient.invoke(matchUri("/repos/${repo.owner}/${repo.name}/teams?page=1&per_page=100")) }
                     .returns(Response(Status.OK).body("[]"))
 
                 val result = client.repositories.getTeams(repo)
@@ -33,8 +33,93 @@ class GitHubRepositorySpec :
                 result.getOrThrow() shouldBe emptyList()
             }
 
+            "follow Link rel=next headers across multiple pages" {
+                val firstTeam =
+                    """
+                    {
+                      "id": 1,
+                      "node_id": "T_kwDOA1",
+                      "url": "https://api.github.com/teams/1",
+                      "html_url": "https://github.com/orgs/${repo.owner}/teams/justice-league",
+                      "name": "Justice League",
+                      "slug": "justice-league",
+                      "description": "The best team",
+                      "privacy": "secret",
+                      "notification_setting": "notifications_enabled",
+                      "permission": "pull",
+                      "members_url": "https://api.github.com/teams/1/members{/member}",
+                      "repositories_url": "https://api.github.com/teams/1/repos"
+                    }
+                    """.trimIndent()
+                val secondTeam =
+                    """
+                    {
+                      "id": 2,
+                      "node_id": "T_kwDOA2",
+                      "url": "https://api.github.com/teams/2",
+                      "html_url": "https://github.com/orgs/${repo.owner}/teams/avengers",
+                      "name": "Avengers",
+                      "slug": "avengers",
+                      "description": "Earth's mightiest heroes",
+                      "privacy": "closed",
+                      "notification_setting": "notifications_enabled",
+                      "permission": "push",
+                      "members_url": "https://api.github.com/teams/2/members{/member}",
+                      "repositories_url": "https://api.github.com/teams/2/repos"
+                    }
+                    """.trimIndent()
+                val linkHeader =
+                    """<https://api.github.com/repos/${repo.owner}/${repo.name}/teams?page=2>; rel="next""""
+
+                every { httpClient.invoke(matchUri("/repos/${repo.owner}/${repo.name}/teams?page=1&per_page=100")) }
+                    .returns(
+                        Response(Status.OK)
+                            .header("Link", linkHeader)
+                            .body("[$firstTeam]"),
+                    )
+                every { httpClient.invoke(matchUri("/repos/${repo.owner}/${repo.name}/teams?page=2&per_page=100")) }
+                    .returns(Response(Status.OK).body("[$secondTeam]"))
+
+                val result = client.repositories.getTeams(repo)
+
+                result.shouldBeInstanceOf<ApiResult.Found<List<GitHubRepositoryTeam>>>()
+                result.getOrThrow() shouldBe
+                    listOf(
+                        GitHubRepositoryTeam(
+                            organization = repo.owner,
+                            id = 1,
+                            nodeId = "T_kwDOA1",
+                            url = "https://api.github.com/teams/1",
+                            htmlUrl = "https://github.com/orgs/${repo.owner}/teams/justice-league",
+                            name = "Justice League",
+                            slug = "justice-league",
+                            description = "The best team",
+                            privacy = "secret",
+                            notificationSetting = "notifications_enabled",
+                            permission = "pull",
+                            membersUrl = "https://api.github.com/teams/1/members{/member}",
+                            repositoriesUrl = "https://api.github.com/teams/1/repos",
+                        ),
+                        GitHubRepositoryTeam(
+                            organization = repo.owner,
+                            id = 2,
+                            nodeId = "T_kwDOA2",
+                            url = "https://api.github.com/teams/2",
+                            htmlUrl = "https://github.com/orgs/${repo.owner}/teams/avengers",
+                            name = "Avengers",
+                            slug = "avengers",
+                            description = "Earth's mightiest heroes",
+                            privacy = "closed",
+                            notificationSetting = "notifications_enabled",
+                            permission = "push",
+                            membersUrl = "https://api.github.com/teams/2/members{/member}",
+                            repositoriesUrl = "https://api.github.com/teams/2/repos",
+                        ),
+                    )
+            }
+
             "return Failure when the API returns a server error" {
-                every { httpClient.invoke(matchUri("/repos/${repo.owner}/${repo.name}/teams")) }
+                every { httpClient.invoke(matchUri("/repos/${repo.owner}/${repo.name}/teams?page=1&per_page=100")) }
                     .returns(Response(Status.INTERNAL_SERVER_ERROR))
 
                 val result = client.repositories.getTeams(repo)

--- a/src/test/kotlin/com.soprasteria.github/GitHubRepositorySpec.kt
+++ b/src/test/kotlin/com.soprasteria.github/GitHubRepositorySpec.kt
@@ -33,39 +33,83 @@ class GitHubRepositorySpec :
                 result.getOrThrow() shouldBe emptyList()
             }
 
+            "return Found with teams when a single page is returned" {
+                val team = Defaults.repositoryTeam(organization = repo.owner)
+
+                every { httpClient.invoke(matchUri("/repos/${repo.owner}/${repo.name}/teams?page=1&per_page=100")) }
+                    .returns(
+                        Response(Status.OK).body(
+                            """
+                            [
+                              {
+                                "id": ${team.id},
+                                "node_id": "${team.nodeId}",
+                                "url": "${team.url}",
+                                "html_url": "${team.htmlUrl}",
+                                "name": "${team.name}",
+                                "slug": "${team.slug}",
+                                "description": "${team.description}",
+                                "privacy": "${team.privacy}",
+                                "notification_setting": "${team.notificationSetting}",
+                                "permission": "${team.permission}",
+                                "members_url": "${team.membersUrl}",
+                                "repositories_url": "${team.repositoriesUrl}"
+                              }
+                            ]
+                            """.trimIndent(),
+                        ),
+                    )
+
+                val result = client.repositories.getTeams(repo)
+
+                result.shouldBeInstanceOf<ApiResult.Found<List<GitHubRepositoryTeam>>>()
+                result.getOrThrow() shouldBe listOf(team)
+            }
+
             "follow Link rel=next headers across multiple pages" {
-                val firstTeam =
+                val firstTeam = Defaults.repositoryTeam(organization = repo.owner)
+                val secondTeam =
+                    Defaults.repositoryTeam(
+                        organization = repo.owner,
+                        id = 2,
+                        name = "Avengers",
+                        slug = "avengers",
+                        description = "Earth's mightiest heroes",
+                        privacy = "closed",
+                        permission = "push",
+                    )
+                val firstTeamBody =
                     """
                     {
-                      "id": 1,
-                      "node_id": "T_kwDOA1",
-                      "url": "https://api.github.com/teams/1",
-                      "html_url": "https://github.com/orgs/${repo.owner}/teams/justice-league",
-                      "name": "Justice League",
-                      "slug": "justice-league",
-                      "description": "The best team",
-                      "privacy": "secret",
-                      "notification_setting": "notifications_enabled",
-                      "permission": "pull",
-                      "members_url": "https://api.github.com/teams/1/members{/member}",
-                      "repositories_url": "https://api.github.com/teams/1/repos"
+                      "id": ${firstTeam.id},
+                      "node_id": "${firstTeam.nodeId}",
+                      "url": "${firstTeam.url}",
+                      "html_url": "${firstTeam.htmlUrl}",
+                      "name": "${firstTeam.name}",
+                      "slug": "${firstTeam.slug}",
+                      "description": "${firstTeam.description}",
+                      "privacy": "${firstTeam.privacy}",
+                      "notification_setting": "${firstTeam.notificationSetting}",
+                      "permission": "${firstTeam.permission}",
+                      "members_url": "${firstTeam.membersUrl}",
+                      "repositories_url": "${firstTeam.repositoriesUrl}"
                     }
                     """.trimIndent()
-                val secondTeam =
+                val secondTeamBody =
                     """
                     {
-                      "id": 2,
-                      "node_id": "T_kwDOA2",
-                      "url": "https://api.github.com/teams/2",
-                      "html_url": "https://github.com/orgs/${repo.owner}/teams/avengers",
-                      "name": "Avengers",
-                      "slug": "avengers",
-                      "description": "Earth's mightiest heroes",
-                      "privacy": "closed",
-                      "notification_setting": "notifications_enabled",
-                      "permission": "push",
-                      "members_url": "https://api.github.com/teams/2/members{/member}",
-                      "repositories_url": "https://api.github.com/teams/2/repos"
+                      "id": ${secondTeam.id},
+                      "node_id": "${secondTeam.nodeId}",
+                      "url": "${secondTeam.url}",
+                      "html_url": "${secondTeam.htmlUrl}",
+                      "name": "${secondTeam.name}",
+                      "slug": "${secondTeam.slug}",
+                      "description": "${secondTeam.description}",
+                      "privacy": "${secondTeam.privacy}",
+                      "notification_setting": "${secondTeam.notificationSetting}",
+                      "permission": "${secondTeam.permission}",
+                      "members_url": "${secondTeam.membersUrl}",
+                      "repositories_url": "${secondTeam.repositoriesUrl}"
                     }
                     """.trimIndent()
                 val linkHeader =
@@ -75,47 +119,15 @@ class GitHubRepositorySpec :
                     .returns(
                         Response(Status.OK)
                             .header("Link", linkHeader)
-                            .body("[$firstTeam]"),
+                            .body("[$firstTeamBody]"),
                     )
                 every { httpClient.invoke(matchUri("/repos/${repo.owner}/${repo.name}/teams?page=2&per_page=100")) }
-                    .returns(Response(Status.OK).body("[$secondTeam]"))
+                    .returns(Response(Status.OK).body("[$secondTeamBody]"))
 
                 val result = client.repositories.getTeams(repo)
 
                 result.shouldBeInstanceOf<ApiResult.Found<List<GitHubRepositoryTeam>>>()
-                result.getOrThrow() shouldBe
-                    listOf(
-                        GitHubRepositoryTeam(
-                            organization = repo.owner,
-                            id = 1,
-                            nodeId = "T_kwDOA1",
-                            url = "https://api.github.com/teams/1",
-                            htmlUrl = "https://github.com/orgs/${repo.owner}/teams/justice-league",
-                            name = "Justice League",
-                            slug = "justice-league",
-                            description = "The best team",
-                            privacy = "secret",
-                            notificationSetting = "notifications_enabled",
-                            permission = "pull",
-                            membersUrl = "https://api.github.com/teams/1/members{/member}",
-                            repositoriesUrl = "https://api.github.com/teams/1/repos",
-                        ),
-                        GitHubRepositoryTeam(
-                            organization = repo.owner,
-                            id = 2,
-                            nodeId = "T_kwDOA2",
-                            url = "https://api.github.com/teams/2",
-                            htmlUrl = "https://github.com/orgs/${repo.owner}/teams/avengers",
-                            name = "Avengers",
-                            slug = "avengers",
-                            description = "Earth's mightiest heroes",
-                            privacy = "closed",
-                            notificationSetting = "notifications_enabled",
-                            permission = "push",
-                            membersUrl = "https://api.github.com/teams/2/members{/member}",
-                            repositoriesUrl = "https://api.github.com/teams/2/repos",
-                        ),
-                    )
+                result.getOrThrow() shouldBe listOf(firstTeam, secondTeam)
             }
 
             "return Failure when the API returns a server error" {


### PR DESCRIPTION
## Summary

Implements #19

`RepositoryService.getTeams()` previously used a plain `GET` and deserialised only the first page, silently truncating repositories with many teams. This PR replaces it with a `PaginatedRequest`-based implementation, consistent with all other paginated list endpoints in the library.

## Changes

- `GitHubRepositoryClient.getTeams()` replaced with a `PaginatedRequest`-based implementation
- Behaviour and method signature unchanged
- Existing tests still pass
- New test added verifying multi-page `Link` header pagination