### PR TITLE
feat: make GitHubClient implement Closeable to release HTTP connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,22 @@ All service methods are `suspend` functions. Call them from a coroutine or use `
 ### Creating a client
 
 ```kotlin
-val client = GitHubClient.create(token = System.getenv("GITHUB_TOKEN"))
+GitHubClient.create(token = System.getenv("GITHUB_TOKEN")).use { client ->
+    val org = client.organizations.get("my-org").getOrThrow()
+    println(org.login)
+}
 ```
 
 To target a GitHub Enterprise Server instance, pass the base URL:
 
 ```kotlin
-val client = GitHubClient.create(
+GitHubClient.create(
     token = System.getenv("GITHUB_TOKEN"),
     baseUrl = "https://github.example.com/api/v3"
-)
+).use { client ->
+    val org = client.organizations.get("my-org").getOrThrow()
+    println(org.login)
+}
 ```
 
 `GitHubClient` exposes three service objects:

--- a/src/main/kotlin/com/soprasteria/github/GitHubClient.kt
+++ b/src/main/kotlin/com/soprasteria/github/GitHubClient.kt
@@ -7,19 +7,20 @@ import org.http4k.core.Uri
 import org.http4k.core.then
 import org.http4k.filter.ClientFilters
 import java.io.Closeable
+import java.util.concurrent.atomic.AtomicReference
 
 class GitHubClient internal constructor(
     httpClient: HttpHandler,
-    private var closeAction: Closeable? = null,
+    initialCloseAction: Closeable? = null,
 ) : Closeable {
+    private val closeAction = AtomicReference<Closeable?>(initialCloseAction)
+
     val organizations = OrganizationService(httpClient)
     val repositories = RepositoryService(httpClient)
     val teams = TeamService(httpClient)
 
     override fun close() {
-        val ownedResource = closeAction ?: return
-        closeAction = null
-        ownedResource.close()
+        closeAction.getAndSet(null)?.close()
     }
 
     companion object {
@@ -35,13 +36,18 @@ class GitHubClient internal constructor(
         ): GitHubClient {
             val apacheClient =
                 PreCannedApacheHttpClients.defaultApacheHttpClient()
-            val httpClient: HttpHandler =
-                ClientFilters
-                    .SetBaseUriFrom(Uri.of(baseUrl))
-                    .then(ClientFilters.BearerAuth(token))
-                    .then(ApacheClient(apacheClient))
+            return try {
+                val httpClient: HttpHandler =
+                    ClientFilters
+                        .SetBaseUriFrom(Uri.of(baseUrl))
+                        .then(ClientFilters.BearerAuth(token))
+                        .then(ApacheClient(apacheClient))
 
-            return GitHubClient(httpClient, apacheClient)
+                GitHubClient(httpClient, apacheClient)
+            } catch (e: Exception) {
+                apacheClient.close()
+                throw e
+            }
         }
     }
 }

--- a/src/main/kotlin/com/soprasteria/github/GitHubClient.kt
+++ b/src/main/kotlin/com/soprasteria/github/GitHubClient.kt
@@ -1,17 +1,26 @@
 package com.soprasteria.github
 
 import org.http4k.client.ApacheClient
+import org.http4k.client.PreCannedApacheHttpClients
 import org.http4k.core.HttpHandler
 import org.http4k.core.Uri
 import org.http4k.core.then
 import org.http4k.filter.ClientFilters
+import java.io.Closeable
 
 class GitHubClient internal constructor(
     httpClient: HttpHandler,
-) {
+    private var closeAction: Closeable? = null,
+) : Closeable {
     val organizations = OrganizationService(httpClient)
     val repositories = RepositoryService(httpClient)
     val teams = TeamService(httpClient)
+
+    override fun close() {
+        val ownedResource = closeAction ?: return
+        closeAction = null
+        ownedResource.close()
+    }
 
     companion object {
         /**
@@ -24,13 +33,15 @@ class GitHubClient internal constructor(
             token: String,
             baseUrl: String = "https://api.github.com",
         ): GitHubClient {
+            val apacheClient =
+                PreCannedApacheHttpClients.defaultApacheHttpClient()
             val httpClient: HttpHandler =
                 ClientFilters
                     .SetBaseUriFrom(Uri.of(baseUrl))
                     .then(ClientFilters.BearerAuth(token))
-                    .then(ApacheClient())
+                    .then(ApacheClient(apacheClient))
 
-            return GitHubClient(httpClient)
+            return GitHubClient(httpClient, apacheClient)
         }
     }
 }

--- a/src/test/kotlin/com.soprasteria.github/GitHubClientSpec.kt
+++ b/src/test/kotlin/com.soprasteria.github/GitHubClientSpec.kt
@@ -2,19 +2,23 @@ package com.soprasteria.github
 
 import com.soprasteria.github.organization.GitHubOrganization
 import com.soprasteria.github.repository.GitHubRepository
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.http4k.core.Body
 import org.http4k.core.HttpHandler
+import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.core.with
 import org.http4k.format.KotlinxSerialization.auto
+import java.io.Closeable
 
 class GitHubClientSpec :
     WordSpec({
@@ -114,6 +118,39 @@ class GitHubClientSpec :
 
                 result.shouldBeInstanceOf<ApiResult.Found<List<GitHubRepository>>>()
                 result.getOrThrow().size shouldBe 2
+            }
+        }
+
+        "close" should {
+
+            "close the internally owned resource without throwing and remain idempotent" {
+                val closeable = mockk<Closeable>(relaxed = true)
+                val closeableClient = GitHubClient(httpClient = httpClient, closeAction = closeable)
+
+                shouldNotThrowAny {
+                    closeableClient.close()
+                    closeableClient.close()
+                }
+
+                verify(exactly = 1) { closeable.close() }
+            }
+
+            "not close a user supplied http handler" {
+                val userSuppliedHandler =
+                    object : HttpHandler, Closeable {
+                        var closed = false
+
+                        override fun invoke(request: Request) = Response(Status.OK)
+
+                        override fun close() {
+                            closed = true
+                        }
+                    }
+                val client = GitHubClient(userSuppliedHandler)
+
+                shouldNotThrowAny { client.close() }
+
+                userSuppliedHandler.closed shouldBe false
             }
         }
     })

--- a/src/test/kotlin/com.soprasteria.github/GitHubClientSpec.kt
+++ b/src/test/kotlin/com.soprasteria.github/GitHubClientSpec.kt
@@ -125,7 +125,7 @@ class GitHubClientSpec :
 
             "close the internally owned resource without throwing and remain idempotent" {
                 val closeable = mockk<Closeable>(relaxed = true)
-                val closeableClient = GitHubClient(httpClient = httpClient, closeAction = closeable)
+                val closeableClient = GitHubClient(httpClient = httpClient, initialCloseAction = closeable)
 
                 shouldNotThrowAny {
                     closeableClient.close()
@@ -151,6 +151,19 @@ class GitHubClientSpec :
                 shouldNotThrowAny { client.close() }
 
                 userSuppliedHandler.closed shouldBe false
+            }
+
+            "close the owned resource when used with use" {
+                val closeable = mockk<Closeable>(relaxed = true)
+                val closeableClient = GitHubClient(httpClient = httpClient, initialCloseAction = closeable)
+
+                val result =
+                    shouldNotThrowAny {
+                        closeableClient.use { "done" }
+                    }
+
+                result shouldBe "done"
+                verify(exactly = 1) { closeable.close() }
             }
         }
     })


### PR DESCRIPTION
## Summary

Implements #24

`GitHubClient` now implements `Closeable`, allowing consumers to release the underlying HTTP connection pool when the client is no longer needed — preventing resource leaks in long-lived applications.

## Changes

- `GitHubClient` implements `Closeable`
- `close()` shuts down the internally-created Apache HTTP connection manager
- User-supplied `HttpHandler` is **not** closed — caller owns its lifecycle
- `create()` wires up a `CloseableHttpClient` and stores a reference for shutdown
- README updated to show the `use { }` pattern
- Unit test verifies `close()` does not throw and that user-supplied handlers are unaffected

## Usage

```kotlin
GitHubClient.create(token = "ghp_...").use { client ->
    val org = client.organizations.get("my-org")
    // connection pool released automatically on exit
}
```