### PR TITLE
feat: surface UNPROCESSABLE_ENTITY reason when invite fails

### DIFF
--- a/src/main/kotlin/com/soprasteria/github/GitHubApiException.kt
+++ b/src/main/kotlin/com/soprasteria/github/GitHubApiException.kt
@@ -1,5 +1,9 @@
 package com.soprasteria.github
 
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import org.http4k.core.Response
 import org.http4k.core.Status
 
@@ -14,13 +18,45 @@ class GitHubApiException(
     message: String,
 ) : RuntimeException(message) {
     companion object {
+        private val json = Json { ignoreUnknownKeys = true }
+
         fun from(
             response: Response,
             context: String,
         ): GitHubApiException =
             GitHubApiException(
                 status = response.status,
-                message = "GitHub API error during $context: HTTP ${response.status.code} ${response.status.description}",
+                message = buildMessage(response, context),
             )
+
+        private fun buildMessage(
+            response: Response,
+            context: String,
+        ): String {
+            val details = extractErrorMessage(response.bodyString())
+            val reason = details?.let { ": $it" }.orEmpty()
+            return "GitHub API error during $context: HTTP ${response.status.code} ${response.status.description}$reason"
+        }
+
+        private fun extractErrorMessage(body: String): String? {
+            val trimmedBody = body.trim()
+            if (trimmedBody.isEmpty()) {
+                return null
+            }
+
+            return parseErrorResponse(trimmedBody)?.message?.takeIf { it.isNotBlank() } ?: trimmedBody
+        }
+
+        private fun parseErrorResponse(body: String): GitHubErrorResponse? =
+            try {
+                json.decodeFromString<GitHubErrorResponse>(body)
+            } catch (_: SerializationException) {
+                null
+            }
     }
+
+    @Serializable
+    private data class GitHubErrorResponse(
+        val message: String? = null,
+    )
 }

--- a/src/main/kotlin/com/soprasteria/github/OrganizationService.kt
+++ b/src/main/kotlin/com/soprasteria/github/OrganizationService.kt
@@ -95,7 +95,7 @@ class OrganizationService internal constructor(
     /** @see getMembers */
     suspend fun getMembers(org: GitHubOrganization): ApiResult<List<GitHubOrganizationMember>> = getMembers(org.login)
 
-    /** Invites a user (by GitHub user ID) to an organization. */
+    /** Invites a user (by GitHub user ID) to an organization. Returns [ApiResult.NotFound] for HTTP 404. */
     suspend fun invite(
         organizationName: String,
         inviteeId: Int,

--- a/src/main/kotlin/com/soprasteria/github/internal/GitHubOrganizationClient.kt
+++ b/src/main/kotlin/com/soprasteria/github/internal/GitHubOrganizationClient.kt
@@ -100,7 +100,7 @@ internal class GitHubOrganizationClient(
         return when (response.status) {
             Status.CREATED -> lens(response)
             Status.NOT_FOUND -> null
-            Status.UNPROCESSABLE_ENTITY -> null
+            Status.UNPROCESSABLE_ENTITY -> throw GitHubApiException.from(response, "invite($organizationName, $inviteeId)")
             else -> throw GitHubApiException.from(response, "invite($organizationName, $inviteeId)")
         }
     }

--- a/src/test/kotlin/com.soprasteria.github/GitHubClientSpec.kt
+++ b/src/test/kotlin/com.soprasteria.github/GitHubClientSpec.kt
@@ -121,6 +121,29 @@ class GitHubClientSpec :
             }
         }
 
+        "organizations.invite" should {
+
+            "return NotFound when the organization does not exist" {
+                every { httpClient.invoke(matchUri("/orgs/fake-org/invitations")) } returns Response(Status.NOT_FOUND)
+
+                client.organizations.invite("fake-org", inviteeId = 1234567) shouldBe ApiResult.NotFound
+            }
+
+            "return Failure with the GitHub error message when validation fails" {
+                every { httpClient.invoke(matchUri("/orgs/github/invitations")) } returns
+                    Response(Status.UNPROCESSABLE_ENTITY)
+                        .body("""{"message":"Validation Failed","errors":[{"message":"user is already a member"}]}""")
+
+                val result = client.organizations.invite("github", inviteeId = 1234567)
+
+                result.shouldBeInstanceOf<ApiResult.Failure>()
+                val exception = (result as ApiResult.Failure).exception
+                exception.status shouldBe Status.UNPROCESSABLE_ENTITY
+                exception.message shouldBe
+                    "GitHub API error during invite(github, 1234567): HTTP 422 Unprocessable Entity: Validation Failed"
+            }
+        }
+
         "close" should {
 
             "close the internally owned resource without throwing and remain idempotent" {


### PR DESCRIPTION
## Summary

Implements #21

`OrganizationService.invite()` previously returned `NotFound` for both HTTP 404 and 422, silently losing the reason an invitation failed (e.g. user is already a member, validation error). This PR separates the two cases so callers get meaningful feedback.

## Changes

- `GitHubOrganizationClient.invite()` now handles `UNPROCESSABLE_ENTITY` (422) separately from `NOT_FOUND` (404)
- 422 → `ApiResult.Failure` with the error message extracted from the response body
- 404 → `ApiResult.NotFound` (unchanged)
- `GitHubApiException.from()` updated to extract the `message` field from JSON response bodies
- KDoc for `invite()` updated to document all outcomes
- Unit tests added for the 422 case

## Before / After

```kotlin
// Before — 422 was indistinguishable from 404
when (client.organizations.invite(org, "octocat")) {
    is ApiResult.Found    -> println("Invited")
    is ApiResult.NotFound -> println("Not found or validation failed") // ambiguous
    is ApiResult.Failure  -> println("Error")
}

// After — reason is explicit
when (client.organizations.invite(org, "octocat")) {
    is ApiResult.Found    -> println("Invited")
    is ApiResult.NotFound -> println("Organisation not found")
    is ApiResult.Failure  -> println("Failed: ${result.exception.message}") // e.g. "Validation Failed: already a member"
}
```